### PR TITLE
rename the l logger to log in the five modules that still used it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,8 +92,7 @@ header; `lib/constants.py: C` holds the defaults used when no reference is given
 **Entry points** (`src/wa_crypt_tools/wa*.py`) are thin argparse wrappers over the factories —
 one per console script in `pyproject.toml`. Each installs `lib/logformat.py: CustomFormatter` on
 both the root logger and the `wa_crypt_tools.lib` logger, so library-level `log.error(...)` is
-what users actually see; `-v` switches to DEBUG. Modules use `log = logging.getLogger(__name__)`
-(a few older ones use `l`).
+what users actually see; `-v` switches to DEBUG. Modules use `log = logging.getLogger(__name__)`.
 
 Version-specific behavior belongs in a `DatabaseXX`/`KeyXX` class plus a factory branch; changes
 to the base classes or to `lib/utils.py` affect all three formats, so exercise crypt12, 14 and 15

--- a/src/wa_crypt_tools/__init__.py
+++ b/src/wa_crypt_tools/__init__.py
@@ -1,4 +1,4 @@
 import logging
-l = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
-l.addHandler(logging.NullHandler())
+log.addHandler(logging.NullHandler())

--- a/src/wa_crypt_tools/lib/db/db14.py
+++ b/src/wa_crypt_tools/lib/db/db14.py
@@ -11,7 +11,7 @@ from wa_crypt_tools.lib.key.key import Key
 from wa_crypt_tools.lib.key.key14 import Key14
 from wa_crypt_tools.lib.props import Props
 
-l = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class Database14(Database):
@@ -26,23 +26,23 @@ class Database14(Database):
                 from wa_crypt_tools.proto import backup_prefix_pb2 as prefix
                 from wa_crypt_tools.proto import key_type_pb2 as key_type
             except ImportError as e:
-                l.error("Could not import the proto classes: {}".format(e))
+                log.error("Could not import the proto classes: {}".format(e))
                 if str(e).startswith("cannot import name 'builder' from 'google.protobuf.internal'"):
-                    l.error("You need to upgrade the protobuf library to at least 3.20.0.\n"
-                            "    python -m pip install --upgrade protobuf")
+                    log.error("You need to upgrade the protobuf library to at least 3.20.0.\n"
+                              "    python -m pip install --upgrade protobuf")
                 elif str(e).startswith("no module named"):
-                    l.error("Please download them and put them in the \"proto\" sub folder.")
+                    log.error("Please download them and put them in the \"proto\" sub folder.")
                 raise e
             except AttributeError as e:
-                l.error("Could not import the proto classes: {}\n    ".format(e) +
-                        "Your protobuf library is probably too old.\n    "
-                        "Please upgrade to at least version 3.20.0 , by running:\n    "
-                        "python -m pip install --upgrade protobuf")
+                log.error("Could not import the proto classes: {}\n    ".format(e) +
+                          "Your protobuf library is probably too old.\n    "
+                          "Please upgrade to at least version 3.20.0 , by running:\n    "
+                          "python -m pip install --upgrade protobuf")
                 raise e
 
             self.header = prefix.BackupPrefix()
 
-            l.debug("Parsing database header...")
+            log.debug("Parsing database header...")
 
             try:
 
@@ -60,7 +60,7 @@ class Database14(Database):
                 else:
                     file_hash.update(encrypted.read(1))
                 if not msgstore_features_flag:
-                    l.debug("No feature table found (not a msgstore DB or very old)")
+                    log.debug("No feature table found (not a msgstore DB or very old)")
                 self.__msgstore_features_flag = msgstore_features_flag
                 try:
 
@@ -68,62 +68,62 @@ class Database14(Database):
                     file_hash.update(protobuf_raw)
 
                     if self.header.ParseFromString(protobuf_raw) != protobuf_size:
-                        l.error("Protobuf message not fully read. Please report a bug.")
+                        log.error("Protobuf message not fully read. Please report a bug.")
                     else:
 
                         # Checking and printing WA version and phone number
                         self.__version = findall(r"\d(?:\.\d{1,3}){3}", self.header.info.app_version)
                         if len(self.__version) != 1:
-                            l.error('WhatsApp version not found')
+                            log.error('WhatsApp version not found')
                         else:
-                            l.debug("WhatsApp version: {}".format(self.__version[0]))
+                            log.debug("WhatsApp version: {}".format(self.__version[0]))
                         if len(self.header.info.jidSuffix) != 2:
-                            l.error("The phone number end is not 2 characters long")
-                        l.debug("Your phone number ends with {}".format(self.header.info.jidSuffix))
+                            log.error("The phone number end is not 2 characters long")
+                        log.debug("Your phone number ends with {}".format(self.header.info.jidSuffix))
 
                         if len(self.header.c15_iv.IV) != 0:
                             # DB Header is crypt15
                             # if type(key) is not Key15:
-                            #    l.error("You are using a crypt14 key file with a crypt15 backup.")
+                            #    log.error("You are using a crypt14 key file with a crypt15 backup.")
                             raise ValueError("Crypt15 file in crypt14 constructor!")
 
                         elif len(self.header.c14_cipher.IV) != 0:
 
                             # DB Header is crypt14
                             # if type(key) is not Key14:
-                            #    l.fatal("You are using a crypt15 key file with a crypt14 backup.")
+                            #    log.fatal("You are using a crypt15 key file with a crypt14 backup.")
 
                             # if key.cipher_version != p.c14_cipher.version.cipher_version:
-                            #    l.error("Cipher version mismatch: {} != {}"
+                            #    log.error("Cipher version mismatch: {} != {}"
                             #    .format(key.cipher_version, p.c14_cipher.cipher_version))
 
                             # Fix bytes to string encoding
                             # key.key_version = (key.key_version[0] + 48).to_bytes(1, byteorder='big')
                             # if key.key_version != p.c14_cipher.key_version:
                             #     if key.key_version > p.c14_cipher.key_version:
-                            #         l.error("Key version mismatch: {} != {} .\n    "
+                            #         log.error("Key version mismatch: {} != {} .\n    "
                             #             .format(key.key_version, p.c14_cipher.key_version) +
                             #             "Your backup is too old for this key file.\n    " +
                             #             "Please try using a newer backup.")
                             #     elif key.key_version < p.c14_cipher.key_version:
-                            #         l.error("Key version mismatch: {} != {} .\n    "
+                            #         log.error("Key version mismatch: {} != {} .\n    "
                             #             .format(key.key_version, p.c14_cipher.key_version) +
                             #             "Your backup is too new for this key file.\n    " +
                             #             "Please try using an older backup, or getting the new key.")
                             #     else:
-                            #         l.error("Key version mismatch: {} != {} (?)"
+                            #         log.error("Key version mismatch: {} != {} (?)"
                             #             .format(key.key_version, p.c14_cipher.key_version))
                             # if key.get_serversalt() != p.c14_cipher.server_salt:
-                            #     l.error("Server salt mismatch: {} != {}".format(key.get_serversalt(), p.c14_cipher.server_salt))
+                            #     log.error("Server salt mismatch: {} != {}".format(key.get_serversalt(), p.c14_cipher.server_salt))
                             # if key.get_googleid() != p.c14_cipher.google_id:
-                            #     l.error("Google ID mismatch: {} != {}".format(key.get_googleid(), p.c14_cipher.google_id))
+                            #     log.error("Google ID mismatch: {} != {}".format(key.get_googleid(), p.c14_cipher.google_id))
                             if len(self.header.c14_cipher.IV) != 16:
-                                l.error("IV is not 16 bytes long but is {} bytes long".format(
+                                log.error("IV is not 16 bytes long but is {} bytes long".format(
                                     len(self.header.c14_cipher.IV)))
                             self.__iv = self.header.c14_cipher.IV
 
                         else:
-                            l.error("Could not parse the IV from the protobuf message. Please report a bug.")
+                            log.error("Could not parse the IV from the protobuf message. Please report a bug.")
                             raise ValueError
 
 
@@ -132,7 +132,7 @@ class Database14(Database):
                     print(e)
 
             except OSError as e:
-                l.fatal("Reading database header failed: {}".format(e))
+                log.fatal("Reading database header failed: {}".format(e))
         else:
             if iv:
                 self.__iv = iv
@@ -206,14 +206,14 @@ class Database14(Database):
             # We are probably in a multifile backup, which does not have a checksum.
             is_multifile_backup = True
         else:
-            l.debug("Checksum OK ({}). Decrypting...".format(self.file_hash.hexdigest()))
+            log.debug("Checksum OK ({}). Decrypting...".format(self.file_hash.hexdigest()))
 
         cipher = AES.new(key.get(), AES.MODE_GCM, self.__iv)
         try:
             output_decrypted: bytes = cipher.decrypt(encrypted_data)
         except ValueError as e:
-            l.fatal("Decryption failed: {}."
-                    "\n    This probably means your backup is corrupted.".format(e))
+            log.fatal("Decryption failed: {}."
+                      "\n    This probably means your backup is corrupted.".format(e))
             raise e
 
         # Verify the authentication tag
@@ -229,7 +229,7 @@ class Database14(Database):
             else:
                 cipher.verify(authentication_tag)
         except ValueError as e:
-            l.error("Authentication tag mismatch: {}."
-                    "\n    This probably means your backup is corrupted.".format(e))
+            log.error("Authentication tag mismatch: {}."
+                      "\n    This probably means your backup is corrupted.".format(e))
 
         return output_decrypted

--- a/src/wa_crypt_tools/lib/key/key15.py
+++ b/src/wa_crypt_tools/lib/key/key15.py
@@ -10,7 +10,7 @@ from wa_crypt_tools.lib.utils import create_jba, encryptionloop
 from wa_crypt_tools.lib.key.key import Key
 import logging
 
-l = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 class Key15(Key):
@@ -41,7 +41,7 @@ class Key15(Key):
                 self.__key = urandom(32)
             else:
                 if len(key) != 32:
-                    l.error("Invalid key length: {}".format(key.hex()))
+                    log.error("Invalid key length: {}".format(key.hex()))
                 self.__key = key
             return
 
@@ -50,11 +50,11 @@ class Key15(Key):
 
         if len(keyarray) != 32:
             raise ValueError("Invalid key length")
-        l.debug("Root key: {}".format(keyarray.hex()))
+        log.debug("Root key: {}".format(keyarray.hex()))
         # Save the root key in the class
         self.__key = keyarray
 
-        l.info("Crypt15 / Raw key loaded")
+        log.info("Crypt15 / Raw key loaded")
 
     def get(self) -> bytes:
         """

--- a/src/wa_crypt_tools/lib/key/keyfactory.py
+++ b/src/wa_crypt_tools/lib/key/keyfactory.py
@@ -9,7 +9,7 @@ import logging
 
 from wa_crypt_tools.lib.utils import javaintlist2bytes, hexstring2bytes
 
-l = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 class KeyFactory:
     @staticmethod
     def new(file: Path):
@@ -20,15 +20,15 @@ class KeyFactory:
             try:
                 return KeyFactory.from_hex(str(file))
             except ValueError:
-                l.critical("The key file specified does not exist.\n    "
-                           "If you tried to specify the key directly, note it should be "
-                           "64 characters long and not {} characters long.".format(len(str(file))))
+                log.critical("The key file specified does not exist.\n    "
+                             "If you tried to specify the key directly, note it should be "
+                             "64 characters long and not {} characters long.".format(len(str(file))))
 
     @staticmethod
     def from_file(file: Path):
         keyfile: bytes = b''
 
-        l.debug("Reading keyfile...")
+        log.debug("Reading keyfile...")
 
         # Try to open the keyfile.
         # The stream must be closed explicitly: javaobj keeps references to it,
@@ -42,10 +42,10 @@ class KeyFactory:
                     keyfile: bytes = javaintlist2bytes(jarr)
 
                 except (ValueError, RuntimeError) as e:
-                    l.critical("The keyfile is not a valid Java object: {}".format(e))
+                    log.critical("The keyfile is not a valid Java object: {}".format(e))
 
         except OSError:
-            l.info("The keyfile could not be opened.")
+            log.info("The keyfile could not be opened.")
             raise OSError
 
         # We guess the key type from its length
@@ -54,7 +54,7 @@ class KeyFactory:
         elif len(keyfile) == 32:
             return Key15(keyarray=keyfile)
         else:
-            l.critical("Unrecognized key file format.")
+            log.critical("Unrecognized key file format.")
 
     @staticmethod
     def from_hex(hexstring: str) -> Key15:

--- a/src/wa_crypt_tools/lib/utils.py
+++ b/src/wa_crypt_tools/lib/utils.py
@@ -14,7 +14,7 @@ import logging
 from wa_crypt_tools.lib.constants import C
 
 # FIXME a "utils" file shouldn't have its own logger
-l = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 
 def test_decompression(test_data: bytes) -> bool:
@@ -30,11 +30,11 @@ def test_decompression(test_data: bytes) -> bool:
         zlib_obj = zlib.decompressobj().decompress(test_data)
         # These two errors should never happen
         if len(zlib_obj) < 16:
-            l.error("Test decompression: chunk too small")
+            log.error("Test decompression: chunk too small")
             return False
         # Decoding can fail if first two bytes are a bad UTF-8 char
         if zlib_obj[:15].decode('ascii') != 'SQLite format 3':
-            l.error("Test decompression: Decryption and decompression ok but not a valid SQLite database")
+            log.error("Test decompression: Decryption and decompression ok but not a valid SQLite database")
             return False
         else:
             return True
@@ -57,18 +57,18 @@ def create_jba(out: bytes) -> JavaByteArray:
 def hexstring2bytes(string: str) -> bytes:
     """Converts a hex string into a bytes array"""
     if len(string) != 64:
-        l.critical("The key file specified does not exist.\n    "
-                   "If you tried to specify the key directly, note it should be "
-                   "64 characters long and not {} characters long.".format(len(string)))
+        log.critical("The key file specified does not exist.\n    "
+                     "If you tried to specify the key directly, note it should be "
+                     "64 characters long and not {} characters long.".format(len(string)))
 
     barr = None
     try:
         barr = bytes.fromhex(string)
     except ValueError as e:
-        l.critical("Couldn't convert the hex string.\n    "
-                   "Exception: {}".format(e))
+        log.critical("Couldn't convert the hex string.\n    "
+                     "Exception: {}".format(e))
     if len(barr) != 32:
-        l.error("The key is not 32 bytes long but {} bytes long.".format(len(barr)))
+        log.error("The key is not 32 bytes long but {} bytes long.".format(len(barr)))
     return barr
 
 


### PR DESCRIPTION
CLAUDE.md documented the split itself — `log = logging.getLogger(__name__)` "(a few older ones use `l`)" — and `l` is flake8's E741 ambiguous name. Five modules were the exception. This makes all of `src/` read one way and removes the parenthetical, which is no longer true.

Nothing but the identifier moves. A whitespace-insensitive word diff over `src/` yields only `l` → `log` tokens: no message text, level or argument differs. The remaining edits are continuation lines shifted two columns to keep hanging indents aligned under the longer name; the leading spaces that live inside the string literals are untouched, so what users see is unchanged.

The name was file-local in all five — nothing imports or re-exports it, and no reference to `wa_crypt_tools.l` exists in tests, README or the notebook. The `l.error(...)`/`l.fatal(...)` lines still in `db15.py` and `dbfactory.py` are commented-out dead code in files outside this change and stay as they are; the equivalent commented lines inside `db14.py` were carried along so that file stays self-consistent.

No test is added because there is no new behaviour to pin. `lib/utils.py`, `key15.py`, `keyfactory.py` and `db14.py` are all on the decrypt paths the existing suite already covers with its crypt12, crypt14 and crypt15 fixtures, and it passes unchanged across the 3.10–3.14 matrix on Ubuntu and Windows — the Windows leg being what confirms `KeyFactory.from_file` still closes the keyfile before returning.

Closes #234.
