### PR TITLE
waencrypt: refuse to overwrite an existing output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ logged its failure and then continued anyway.
   take the `key` argument they ignored.
 - `waencrypt` installs its log handler on the library logger, so library messages are
   formatted like every other tool's.
+- **`waencrypt` refuses to overwrite an existing output file**, and takes `-y`/`--yes` to do
+  it anyway, matching `wacreatekey`. The output was an `argparse.FileType('wb')`, which is
+  opened while the arguments are still being parsed: pointing the tool at an existing backup
+  emptied it before any check had run, and a run that then failed -- an unusable key, say --
+  left nothing behind.
 
 ## Version 0.0.9
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,10 @@ tests/res/test9.zip <out>` with the last 16 bytes then dropped.
   `tests/tools-invocation/test_waencrypt.py`: `Props(v_features=...)` never sets `max_feature`, so
   `get_features()` -- which only `Database14.encrypt` calls -- raises `AttributeError`. Drop the
   marker when `props.py` is fixed. `--multi-file` and `--noparse` are declared and never read.
-  A failed run still truncates the output file to zero first, because argparse's `FileType('wb')`
-  opens it before anything is validated.
+  The `encrypted` positional is deliberately a plain `str` and not an `argparse.FileType('wb')`:
+  that type opens the file during parsing, so it was emptied before any check had run. The
+  existence guard at the top of `encrypt()` only works while it stays a path. `wadecrypt` still
+  has the `FileType('wb')` shape for its own output.
 - CI (`.github/workflows/lint-test-coverage.yml`) runs the matrix Python 3.10–3.14 on Ubuntu and
   Windows. On Windows, file handles must be closed before deletion — `KeyFactory.from_file` opens
   the keyfile in a `with` block for exactly this reason.

--- a/README.md
+++ b/README.md
@@ -60,11 +60,14 @@ wadecrypt.py:271        : [I] Done
 ## Encrypt a file with waencrypt (BETA)
 
 ```
-usage: waencrypt [-h] [-f] [-v] [--enable-features [ENABLE_FEATURES ...]] [--max-feature MAX_FEATURE]
+usage: waencrypt [-h] [-f] [-y] [-v] [--enable-features [ENABLE_FEATURES ...]] [--max-feature MAX_FEATURE]
                  [--multi-file] [--type {12,14,15}] [--iv IV] [--reference REFERENCE] [--noparse]
                  [--wa-version WA_VERSION] [--jid JID] [--backup-version BACKUP_VERSION] [--no-compress]
                  [keyfile] [decrypted] [encrypted]
 ```
+
+`waencrypt` will not write over a file that already exists; pass `-y`/`--yes` if that is what
+you want.
 
 Encryption is more complex and untested: it is advised to use another encrypted file 
 from the same account, which we will call "reference".  

--- a/src/wa_crypt_tools/waencrypt.py
+++ b/src/wa_crypt_tools/waencrypt.py
@@ -3,6 +3,7 @@ import hashlib
 import os
 import zlib
 import logging
+from pathlib import Path
 
 from wa_crypt_tools.lib.constants import C
 from wa_crypt_tools.lib.db.db import Database
@@ -28,10 +29,15 @@ def parsecmdline() -> argparse.Namespace:
                              'Default: encrypted_backup.key')
     parser.add_argument('decrypted', nargs='?', type=argparse.FileType('rb'), default="msgstore.db",
                         help='The input file. Default: msgstore.db')
-    parser.add_argument('encrypted', nargs='?', type=argparse.FileType('wb'), default="msgstore.db.crypt15",
+    # Deliberately not argparse.FileType('wb'): that opens the file while the arguments are
+    # still being parsed, so a run that fails for any reason -- an unreadable key, the wrong
+    # --type -- would already have truncated whatever was at that path.
+    parser.add_argument('encrypted', nargs='?', type=str, default="msgstore.db.crypt15",
                         help='The encrypted crypt15 or crypt14 file. Default: msgstore.db.crypt15')
     parser.add_argument('-f', '--force', action='store_true',
                         help='Carry on when an integrity check fails. Default: stop')
+    parser.add_argument('-y', '--yes', action='store_true',
+                        help='Overwrite the output file if it exists.')
     parser.add_argument('-v', '--verbose', action='store_true', help='Prints all offsets and messages')
     parser.add_argument('--enable-features', type=int, nargs='*', default=C.DEFAULT_FEATURE_LIST,
                         help='Enables the specified features. ')
@@ -76,6 +82,11 @@ def main():
 
 
 def encrypt(args):
+    # Before anything else, and before the output is opened: refusing after the fact would
+    # mean the file had already been emptied.
+    if Path(args.encrypted).is_file() and not args.yes:
+        log.fatal("The output file already exists. Use --yes to overwrite it.")
+        exit(1)
     # Read the key file
     key = KeyFactory.new(args.keyfile)
     # If specified, use the IV from the command line
@@ -109,11 +120,10 @@ def encrypt(args):
     else:
         compressed = zlib.compress(data, 1)
         encrypted = db.encrypt(key, props, compressed)
-    args.encrypted.write(encrypted)
-    # Close the files
+    with open(args.encrypted, 'wb') as f:
+        f.write(encrypted)
     log.info("Done!")
     args.decrypted.close()
-    args.encrypted.close()
 
 
 if __name__ == '__main__':

--- a/tests/tools-invocation/test_waencrypt.py
+++ b/tests/tools-invocation/test_waencrypt.py
@@ -101,6 +101,47 @@ class TestReference:
         assert ret == 0, out
 
 
+class TestExistingOutput:
+    """
+    waencrypt refuses to write over a file that is already there.
+
+    The output used to be an argparse.FileType('wb'), which opens it while the arguments are
+    still being parsed: pointing the tool at an existing backup emptied it before a single
+    check had run, and a run that then failed left nothing behind.
+    """
+
+    def teardown_method(self):
+        cleanup()
+
+    def write_something(self):
+        with open(OUT, 'wb') as f:
+            f.write(b'PRECIOUS')
+
+    def test_an_existing_output_stops_the_run(self):
+        self.write_something()
+        out, ret = Propen("waencrypt {} {} {}".format(KEY15, PLAIN, OUT))
+        assert ret != 0
+        assert "output file already exists" in out
+        with open(OUT, 'rb') as f:
+            assert f.read() == b'PRECIOUS'
+
+    def test_yes_overwrites_it(self):
+        self.write_something()
+        out, ret = Propen("waencrypt --yes {} {} {}".format(KEY15, PLAIN, OUT))
+        assert ret == 0, out
+        out, ret = Propen("wadecrypt {} {} {}".format(KEY15, OUT, ROUNDTRIP))
+        assert ret == 0, out
+        assert cmp_files(ROUNDTRIP, PLAIN)
+
+    def test_a_run_that_fails_leaves_the_output_alone(self):
+        # Even with --yes: the file is opened only once there is something to write to it.
+        self.write_something()
+        out, ret = Propen("waencrypt --yes tests/res/test.json {} {}".format(PLAIN, OUT))
+        assert ret != 0
+        with open(OUT, 'rb') as f:
+            assert f.read() == b'PRECIOUS'
+
+
 class TestFailures:
     def teardown_method(self):
         cleanup()


### PR DESCRIPTION
The output positional was an `argparse.FileType('wb')`, which opens — and truncates — the file while the arguments are still being parsed: before the key is read, before `--type` is checked, before anything. Pointing `waencrypt` at an existing backup emptied it immediately, and a run that then failed left nothing behind:

```
$ echo PRECIOUS > backup.crypt15
$ waencrypt not-a-key.json msgstore.db backup.crypt15
[C] The keyfile is not a valid Java object: Invalid file magic: 0x7b0a
$ wc -c backup.crypt15
0
```

A check added after `parse_args()` would have been inspecting a file it had already emptied, so the positional is now a plain path, opened only once there are bytes to write to it, and `encrypt()` refuses up front if it is already a file.

`-y`/`--yes` overrides — the same flag `wacreatekey` already uses for this, so the two tools now behave the same way. Without an override the tool could not overwrite at all, which would break ordinary re-runs.

### Verified

Four cases by hand: a fresh path writes; an existing path exits 1 with the file untouched; `-y` overwrites and round-trips through `wadecrypt`; and a bad key with `-y` leaves the target intact where it used to zero it. Three tests in `TestExistingOutput` cover the first, second and fourth.

Full suite 230 passed / 1 xfailed, coverage 94% (`waencrypt` 96% → 97%). Blocking flake8 clean.

Also updates CHANGELOG (under 0.2.0), the README usage line, and the CLAUDE.md note — which now warns that the guard only holds while that positional stays a `str`, since switching it back to `FileType` would silently defeat it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKq8MBAKTJkMd5DGNY3jdW