### PR TITLE
Track WhatsApp's compression level instead of assuming level 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ logged its failure and then continued anyway.
   `argparse.FileType('wb')`, which is opened while the arguments are still being parsed:
   pointing either tool at an existing file emptied it before any check had run, and a run
   that then failed -- an unusable key, say -- left nothing behind.
+- **`waguess` works on current backups again.** It gates on the first two decrypted bytes
+  matching a known zlib header before spending time on a full test decryption, and that
+  list held only `78 01`, the header for levels 0 and 1. WhatsApp compressed at level 1 when
+  that was written and compresses at level 9 now, so every current backup was rejected
+  outright and reported as "the key does not match this backup" on a key that matched. All
+  four zlib headers are accepted now.
+- **Incremental and multi-file backups are recognised by the guessing logic.** Their payload
+  is a ZIP that WhatsApp compresses like any other, so the ZIP header only appears after
+  decompression; `test_decompression` looked for it only before, and demanded a SQLite
+  header after. Found against a real incremental backup, which `waguess` failed to decrypt
+  in 23 seconds and now handles in under one.
+- **`waencrypt` takes `-c`/`--compression-level`**, defaulting to 9. The level was hardcoded
+  to 1, again matching the WhatsApp of the time; re-encrypting a real 2.26 msgstore came out
+  3.5% larger than the original at level 1 and within 2 bytes of it at level 9. Level 1
+  stays reachable for reproducing older backups.
+- **`--reference` now supplies the compression level too**, so reproducing a backup no longer
+  means remembering `-c` alongside it. The reference's zlib header names a band of levels and
+  the top of that band is used, which is exact for the only two levels WhatsApp has used. An
+  explicit `-c` still wins, and a reference whose payload is not zlib warns and falls back.
+- `wainfo` printed the crypt15 IV on the same line as the heading that introduces it, unlike
+  the crypt14 branch beside it, so anything reading its output line by line missed the IV.
 
 ## Version 0.0.9
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,7 +106,34 @@ when touching them (`tests/res/` has a fixture backup in each format, all decryp
 multi-file one, so its plaintext is a ZIP (`test9.zip`) rather than a zlib'd SQLite database and
 it has no trailing md5, which puts the tag where the checksum would be. It was made with
 `waencrypt --no-compress --iv 000102030405060708090a0b0c0d0e0f tests/res/encrypted_backup.key
-tests/res/test9.zip <out>` with the last 16 bytes then dropped.
+tests/res/test9.zip <out>` with the last 16 bytes then dropped. Note `--no-compress`: it is a
+*raw* ZIP, so it exercises the multi-file reader but not the guessing logic, which sees a real
+multi-file backup as a compressed one (see below).
+
+**Compression level tracks WhatsApp's own and is load-bearing in two places.** WhatsApp
+compressed backups at zlib level 1 when this project was written and compresses at level 9
+now. Two things had been written against level 1 and broke silently when it moved:
+`waencrypt`'s hardcoded level, now `-c`/`--compression-level` defaulting to 9; and
+`C.ZLIB_HEADERS`, the first-two-bytes gate `waguess` applies before it will spend time on a
+candidate decryption, which held only `78 01` and so rejected every current backup with
+"the key does not match this backup". All four zlib headers are listed there now, one per
+band of levels, so the gate no longer depends on which level WhatsApp picks. Anything that
+compares the *size* of an encrypted file against a real backup is really comparing
+compression levels, and a re-encryption at 9 lands within a couple of bytes of the original.
+`--reference` reads the level off the reference's own zlib header, so it reproduces a backup
+of any era without being told; the default only applies when there is no reference.
+
+`waguess` is for msgstore and nothing else, by design. Its only signal that a candidate offset
+decrypted correctly is `test_decompression`, which demands a SQLite or ZIP payload, so the
+sticker (WebP) and settings (JSON) backups under `WhatsApp/Backups/` come back as "the key
+does not match this backup" -- and files below `HEADER_SIZE` are refused as too small. Both
+are intended: `wadecrypt` and `wainfo` handle every one of those files, and broadening the
+check would cost the search its only defence against false offsets.
+
+An incremental backup (`msgstore-increment-*.crypt15`) is a third shape: its plaintext is a
+ZIP of JSON changesets, but a *compressed* one, so the ZIP header only appears after
+decompression. `lib/utils.py: test_decompression` checks for it both before and after for
+that reason -- before catches `stickers.backup.crypt15`, after catches the real thing.
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,15 @@ wadecrypt.py:271        : [I] Done
 usage: waencrypt [-h] [-f] [-y] [-v] [--enable-features [ENABLE_FEATURES ...]] [--max-feature MAX_FEATURE]
                  [--multi-file] [--type {12,14,15}] [--iv IV] [--reference REFERENCE] [--noparse]
                  [--wa-version WA_VERSION] [--jid JID] [--backup-version BACKUP_VERSION] [--no-compress]
-                 [keyfile] [decrypted] [encrypted]
+                 [-c [0-9]] [keyfile] [decrypted] [encrypted]
 ```
 
 `waencrypt` will not write over a file that already exists; pass `-y`/`--yes` if that is what
 you want.
+
+`-c`/`--compression-level` is the zlib level, 9 by default, which is what WhatsApp uses now.
+It compressed at 1 historically. With `--reference` the level is taken from the reference, so
+reproducing an older backup needs nothing extra; pass `-c` to override it.
 
 Encryption is more complex and untested: it is advised to use another encrypted file 
 from the same account, which we will call "reference".  

--- a/src/wa_crypt_tools/lib/constants.py
+++ b/src/wa_crypt_tools/lib/constants.py
@@ -1,12 +1,27 @@
 class C:
     # These constants are only used by the guessing logic.
-    # zlib magic header is 78 01 (Low Compression).
-    # The first two bytes of the decrypted data should be those,
-    # in case of single file backup, or PK in case of multi file.
+    # The first two bytes of the decrypted data are a zlib header for a single file backup,
+    # or PK for a multi file one stored uncompressed. With CMF 0x78 -- a 32K window, which is
+    # what every level uses -- the check byte leaves exactly four possible headers, one per
+    # band of compression levels. WhatsApp compressed at level 1 historically and at level 9
+    # now, so a list holding only 78 01 stopped recognising current backups entirely.
     ZLIB_HEADERS = [
-        b'x\x01',
+        b'x\x01',  # levels 0-1
+        b'x\x5e',  # levels 2-5
+        b'x\x9c',  # level 6, zlib's default
+        b'x\xda',  # levels 7-9, what WhatsApp uses now
         b'PK'
     ]
+    # A zlib header names a band of levels, not one level, so reproducing a stream from its
+    # header alone means picking a representative: the top of each band, which is exact for
+    # the only two levels WhatsApp has ever used, 1 and 9.
+    ZLIB_HEADER_LEVELS = {
+        b'x\x01': 1,
+        b'x\x5e': 5,
+        b'x\x9c': 6,
+        b'x\xda': 9,
+    }
+    DEFAULT_COMPRESSION_LEVEL = 9
     ZIP_HEADER = b'PK\x03\x04'
     # Size of bytes to test (number chosen arbitrarily, but values less than ~310 makes test_decompression fail)
     HEADER_SIZE = 384

--- a/src/wa_crypt_tools/lib/utils.py
+++ b/src/wa_crypt_tools/lib/utils.py
@@ -33,6 +33,11 @@ def test_decompression(test_data: bytes) -> bool:
         if len(zlib_obj) < 16:
             log.error("Test decompression: chunk too small")
             return False
+        # A multi-file or incremental backup is a ZIP that WhatsApp compresses like any
+        # other payload, so its header only shows up once we have decompressed. The check
+        # above only catches a ZIP stored uncompressed.
+        if zlib_obj[:4] == C.ZIP_HEADER:
+            return True
         # Decoding can fail if first two bytes are a bad UTF-8 char
         if zlib_obj[:15].decode('ascii') != 'SQLite format 3':
             log.error("Test decompression: Decryption and decompression ok but not a valid SQLite database")
@@ -160,7 +165,7 @@ def header_info(header):
     string: str = ""
     if header.c15_iv.IV:
         string += "Crypt15 info:\n"
-        string += str("Header information in your crypt15 file:")
+        string += str("Header information in your crypt15 file:\n")
         string += str("IV: {}\n".format(header.c15_iv.IV.hex()))
     if header.c14_cipher.IV:
         string += str("Header information in your crypt14 file:\n")

--- a/src/wa_crypt_tools/waencrypt.py
+++ b/src/wa_crypt_tools/waencrypt.py
@@ -5,6 +5,8 @@ import zlib
 import logging
 from pathlib import Path
 
+from Cryptodome.Cipher import AES
+
 from wa_crypt_tools.lib.constants import C
 from wa_crypt_tools.lib.db.db import Database
 from wa_crypt_tools.lib.db.db12 import Database12
@@ -61,6 +63,16 @@ def parsecmdline() -> argparse.Namespace:
                         help='The backup version to use in the header of the encrypted file. Default: 0')
     parser.add_argument('--no-compress', action='store_true',
                         help='Do not compress the file. This will make the backup not working. Only used in development. Default: false')
+    # This was hardcoded to 1, which is what WhatsApp itself used when it was written.
+    # Current WhatsApp compresses at 9, so that is the default now -- but old backups were
+    # built at 1 and reproducing one has to stay possible, hence the option. The default is
+    # resolved in encrypt(), not here, so that --reference can supply it instead.
+    parser.add_argument('-c', '--compression-level', type=int, choices=range(0, 10),
+                        metavar='[0-9]', default=None,
+                        help='The zlib compression level to use. Lower is faster and bigger. '
+                             'WhatsApp used 1 historically and uses 9 now. '
+                             'Default: the level of --reference, else {}.'
+                             .format(C.DEFAULT_COMPRESSION_LEVEL))
     return parser.parse_args()
 
 
@@ -79,6 +91,26 @@ def main():
     except WaCryptError as e:
         log.critical(str(e))
         exit(1)
+
+
+def compression_level_of(key, reference, stream):
+    """
+    The zlib level the reference was compressed at, or None if it cannot be told.
+
+    The level is part of what --reference reproduces: a backup from the era when WhatsApp
+    compressed at 1 comes back out 3.5% larger at the current default of 9. The factory
+    leaves the stream on the first ciphertext byte, so the level is two bytes away.
+    """
+    head = AES.new(key.get(), AES.MODE_GCM, reference.get_iv()).decrypt(stream.read(2))
+    level = C.ZLIB_HEADER_LEVELS.get(head)
+    if level is None:
+        # A multi-file reference is a ZIP, and --no-compress leaves anything at all there.
+        log.warning("Cannot tell the compression level of the reference: it starts {}, "
+                    "which is not a zlib header. Using {}."
+                    .format(head.hex(), C.DEFAULT_COMPRESSION_LEVEL))
+    else:
+        log.debug("Reference was compressed at level {}".format(level))
+    return level
 
 
 def encrypt(args):
@@ -108,6 +140,10 @@ def encrypt(args):
             reference = e.data
         iv: bytes = reference.get_iv()
         props = reference.props
+        if args.compression_level is None:
+            args.compression_level = compression_level_of(key, reference, args.reference)
+    if args.compression_level is None:
+        args.compression_level = C.DEFAULT_COMPRESSION_LEVEL
     data = args.decrypted.read()
     if args.type == 15:
         db = Database15(iv=iv)
@@ -118,7 +154,7 @@ def encrypt(args):
     if args.no_compress:
         encrypted = db.encrypt(key, props, data)
     else:
-        compressed = zlib.compress(data, 1)
+        compressed = zlib.compress(data, args.compression_level)
         encrypted = db.encrypt(key, props, compressed)
     with open(args.encrypted, 'wb') as f:
         f.write(encrypted)

--- a/tests/lib/test_utils.py
+++ b/tests/lib/test_utils.py
@@ -92,6 +92,13 @@ class TestTestDecompression:
     def test_sqlite_header_is_accepted(self):
         assert decompresses_to_a_database(zlib.compress(SQLITE)) is True
 
+    def test_a_compressed_zip_is_accepted(self):
+        # What a real incremental or multi-file backup actually is: a ZIP that WhatsApp then
+        # zlib-compresses, so the ZIP header only appears *after* decompression. The check
+        # looked for it only before, and so rejected every one of them -- which left waguess
+        # unable to find the offsets of a backup it had decrypted perfectly well.
+        assert decompresses_to_a_database(zlib.compress(read("tests/res/test9.zip"))) is True
+
 
 class TestEncryptionLoop:
     """The HMAC-SHA256 loop mirrored in utils/WA_HMACSHA256_Loop.java."""
@@ -197,6 +204,12 @@ class TestHeaderInfo:
         assert "crypt14" in string
         assert header.c14_cipher.IV.hex() in string
         assert header.c14_cipher.server_salt.hex() in string
+
+    def test_the_crypt15_iv_is_on_a_line_of_its_own(self):
+        # "...in your crypt15 file:" ran straight into "IV: ", unlike the crypt14 branch just
+        # below it, so anything reading wainfo's output line by line never saw the IV.
+        header = self.header_of("tests/res/msgstore.db.crypt15")
+        assert "IV: {}".format(header.c15_iv.IV.hex()) in header_info(header).splitlines()
 
     def test_a_backup_without_a_feature_table(self):
         string = header_info(self.header_of("tests/res/msgstore-noexpiry.db.crypt14"))

--- a/tests/tools-invocation/test_waencrypt.py
+++ b/tests/tools-invocation/test_waencrypt.py
@@ -6,6 +6,7 @@ zlib-ng (CPython 3.14+ on Windows) compresses differently, so only the plaintext
 across platforms. The one byte-for-byte check is guarded on that.
 """
 
+import os.path
 import zlib
 
 import pytest
@@ -82,6 +83,8 @@ class TestReference:
         cleanup()
 
     def test_a_crypt15_reference_reproduces_the_original(self):
+        # The fixture is a 2.22 backup, compressed at level 1, and no -c is passed here:
+        # reproducing it byte-for-byte means the level has to come off the reference too.
         out, ret = Propen("waencrypt --reference tests/res/msgstore.db.crypt15 {} {} {}"
                           .format(KEY15, PLAIN, OUT))
         assert ret == 0, out
@@ -156,3 +159,64 @@ class TestFailures:
                           .format(KEY15, PLAIN, OUT))
         assert ret != 0
         assert "does not look like a crypt12, 14 or 15 database" in out
+
+
+class TestCompressionLevel:
+    """
+    The level was hardcoded to 1, which is what WhatsApp itself used at the time. Current
+    WhatsApp compresses at 9 -- a real 2.26 msgstore re-encrypted at 1 came out 3.5% larger
+    than the original, and at 9 landed within 4 bytes of it. Both levels have to stay
+    reachable, so the level is an option and 9 is only the default.
+    """
+
+    REF = "waencrypt-test-reference.crypt15"
+
+    def teardown_method(self):
+        cleanup()
+        rm_if_found(self.REF)
+
+    def size_at(self, *extra: str) -> int:
+        out, ret = Propen(["waencrypt", *extra, KEY15, PLAIN, OUT])
+        assert ret == 0, out
+        size = os.path.getsize(OUT)
+        rm_if_found(OUT)
+        return size
+
+    def test_nine_compresses_better_than_one(self):
+        assert self.size_at("-c", "9") < self.size_at("-c", "1")
+
+    def test_the_default_is_nine(self):
+        assert self.size_at() == self.size_at("-c", "9")
+
+    @pytest.mark.parametrize("level", ["1", "6", "9"])
+    def test_every_level_still_round_trips(self, level):
+        roundtrip(KEY15, "-c", level)
+        assert cmp_files(PLAIN, ROUNDTRIP)
+
+    @pytest.mark.parametrize("level", ["-1", "10", "abc"])
+    def test_a_level_outside_the_range_is_refused(self, level):
+        out, ret = Propen(["waencrypt", "-c", level, KEY15, PLAIN, OUT])
+        assert ret != 0, out
+
+    def test_the_level_is_taken_from_the_reference(self):
+        # --reference exists to reproduce a backup, and the level is part of that: a
+        # reference built at 1 has to come back out at 1, not at the default of 9.
+        out, ret = Propen(["waencrypt", "-c", "1", KEY15, PLAIN, self.REF])
+        assert ret == 0, out
+        out, ret = Propen(["waencrypt", "--reference", self.REF, KEY15, PLAIN, OUT])
+        assert ret == 0, out
+        assert os.path.getsize(OUT) == os.path.getsize(self.REF)
+
+    def test_an_explicit_level_beats_the_reference(self):
+        out, ret = Propen(["waencrypt", "-c", "1", KEY15, PLAIN, self.REF])
+        assert ret == 0, out
+        out, ret = Propen(["waencrypt", "-c", "9", "--reference", self.REF, KEY15, PLAIN, OUT])
+        assert ret == 0, out
+        assert os.path.getsize(OUT) < os.path.getsize(self.REF)
+
+    def test_no_compress_ignores_the_level(self):
+        # --no-compress writes the plaintext through untouched, so a level alongside it
+        # cannot silently start compressing.
+        out, ret = Propen(["waencrypt", "--no-compress", "-c", "9", KEY15, PLAIN, OUT])
+        assert ret == 0, out
+        assert os.path.getsize(OUT) > os.path.getsize(PLAIN)

--- a/tests/tools-invocation/test_waguess.py
+++ b/tests/tools-invocation/test_waguess.py
@@ -63,6 +63,42 @@ class TestWaGuess:
         assert written.startswith(original)
 
 
+class TestCompressionLevels:
+    """
+    The search gates on the first two decrypted bytes matching a known zlib header before it
+    spends time on a full test decryption. That list held only 78 01, the header for level 0
+    and 1, which is what WhatsApp compressed with when this was written. It moved to level 9
+    since -- a real 2.26 backup starts 78 da -- and every one of those was rejected outright,
+    reported as "the key does not match this backup" on a key that matched perfectly.
+    """
+
+    ENCRYPTED = "waguess-level-test.crypt15"
+
+    def teardown_method(self):
+        rm_if_found(OUT)
+        rm_if_found(self.ENCRYPTED)
+
+    # 0/1 -> 78 01, 2-5 -> 78 5e, 6 -> 78 9c, 7-9 -> 78 da: every zlib header there is.
+    @pytest.mark.parametrize("level", ["1", "3", "6", "9"])
+    def test_a_backup_at_any_compression_level_is_found(self, level):
+        out, ret = Propen(["waencrypt", "-c", level, KEY15,
+                           "tests/res/msgstore.db", self.ENCRYPTED])
+        assert ret == 0, out
+        out, ret = Propen("waguess {} {} {}".format(KEY15, self.ENCRYPTED, OUT))
+        assert ret == 0, out
+        assert cmp_files(OUT, "tests/res/msgstore.db")
+
+    def test_a_zip_payload_at_the_current_level_is_found(self):
+        # What an incremental backup is: a ZIP, compressed at the level WhatsApp uses now.
+        # It needs the header list and the ZIP-after-decompression check together.
+        out, ret = Propen(["waencrypt", "-c", "9", KEY15,
+                           "tests/res/test9.zip", self.ENCRYPTED])
+        assert ret == 0, out
+        out, ret = Propen("waguess {} {} {}".format(KEY15, self.ENCRYPTED, OUT))
+        assert ret == 0, out
+        assert cmp_files(OUT, "tests/res/test9.zip")
+
+
 class TestWaGuessFailures:
     def teardown_method(self):
         rm_if_found(OUT)


### PR DESCRIPTION
Found by exercising the tools against a real WhatsApp 2.26 backup pulled from a rooted device over adb, rather than against the fixtures.

WhatsApp compressed backups at zlib level 1 when this project was written and compresses at **level 9** now. Three things had been written against level 1 and broke silently when it moved.

## `waguess` rejected every current backup

`C.ZLIB_HEADERS` — the first-two-bytes gate `waguess` applies before it will spend time on a candidate decryption — held only `78 01`. Current backups start `78 da`, so the gate never opened and every one was reported as:

> Could not guess the offsets: the key does not match this backup, or the file is not a WhatsApp database.

on a key that matched perfectly. All four zlib headers are listed now, one per band of levels, so the gate no longer depends on which level WhatsApp picks.

## Incremental and multi-file backups were rejected too

`test_decompression` looked for a ZIP header only *before* decompressing. A real incremental backup is a ZIP of JSON changesets that WhatsApp compresses like any other payload, so its header only appears *after* — and every one was rejected even once the gate above let it through. Both fixes are needed for that shape.

## `waencrypt` compressed at the old level

`zlib.compress(data, 1)` was hardcoded. It takes `-c`/`--compression-level` now, defaulting to 9, with level 1 still reachable for reproducing older backups. `--reference` supplies the level itself, read off the reference's own zlib header, so reproducing a backup of any era needs nothing extra and an explicit `-c` still wins.

## Measured against the real backup

| | before | after |
|---|---|---|
| `waguess`, real 55 MB msgstore | ❌ | ✅ 4.1 s |
| `waguess`, real incremental backup | ❌ after 23 s | ✅ 0.65 s |
| `wainfo` IV greppable | ❌ | ✅ |
| `waencrypt` vs WhatsApp's own output size | +1,948,190 B | **−2 B** |

Also fixed: `wainfo` printed the crypt15 IV on the same line as the heading that introduces it, unlike the crypt14 branch beside it, so anything reading its output line by line missed the IV.

## Deliberately not changed

`waguess` stays msgstore-only. The sticker (WebP) and settings (JSON) backups under `WhatsApp/Backups/` are rejected by the same payload check, and files below `HEADER_SIZE` are refused as too small — but that check is the search's only defence against false offsets, so broadening it would cost more than it buys. `wadecrypt` and `wainfo` read all of them correctly (verified across 12 non-msgstore backups: SQLite, JSON and WebP payloads). Recorded in CLAUDE.md so it is not mistaken for a bug later.

## Testing

Test-first for every fix. 252 passed, 1 xfailed, 94% coverage; `lib/utils.py` at 100%.

New tests cover every zlib level band, a compressed-ZIP payload, the level flag and its range validation, and reference inference. `test_a_crypt15_reference_reproduces_the_original` needed no change in the end — the fixture is a level-1 backup and inference reproduces it byte-for-byte on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKq8MBAKTJkMd5DGNY3jdW