### PR TITLE
Reproduce a backup byte for byte on re-encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,25 @@ logged its failure and then continued anyway.
   means remembering `-c` alongside it. The reference's zlib header names a band of levels and
   the top of that band is used, which is exact for the only two levels WhatsApp has used. An
   explicit `-c` still wins, and a reference whose payload is not zlib warns and falls back.
+- **`waencrypt --reference` reproduces a backup byte for byte.** Verified against 13 real
+  backups off a 2.26 device -- a 55 MB msgstore, an incremental backup, stickers, settings,
+  and files as small as 239 bytes -- every one of which now comes back with the md5 it went
+  in with. Three separate things had to be fixed for that:
+  - The header was rebuilt from `Props` alone, which dropped the fields this schema does not
+    model. Real backups carry an unknown varint field 6, so every re-encryption was 2 bytes
+    short of the original no matter what else was right. `DatabaseFactory` keeps the header
+    it parsed now and `encrypt()` builds on top of it, which also future-proofs against
+    WhatsApp adding fields this library has never heard of.
+  - `Database15` wrote the `0x01` feature-table flag unconditionally, so every backup that is
+    not a msgstore -- `wa.db`, `chatsettingsbackup`, the stickers -- came out a byte longer
+    than it went in. Whether the source had it is recorded and honoured.
+  - The compression level, above.
+- **`waencrypt --type 14 --reference` works.** It raised `AttributeError: 'Props' object has
+  no attribute 'max_feature'` from `get_features()`, which `Database14.encrypt` called to
+  decide whether to write the feature table flag; it reads that off the reference now. The
+  underlying hole is fixed too: `Props(v_features=...)`, which is how a parsed header becomes
+  props, never set `max_feature`, so `get_features()` raised on every props built that way.
+  It is taken from the protobuf schema now.
 - `wainfo` printed the crypt15 IV on the same line as the heading that introduces it, unlike
   the crypt14 branch beside it, so anything reading its output line by line missed the IV.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,16 @@ does not match this backup" -- and files below `HEADER_SIZE` are refused as too 
 are intended: `wadecrypt` and `wainfo` handle every one of those files, and broadening the
 check would cost the search its only defence against false offsets.
 
+**A re-encryption is built on the parsed header, not from scratch.** `DatabaseFactory` keeps the
+`BackupPrefix` it parsed on `db.prefix` and whether the `0x01` feature-table flag was there on
+`db.feature_table`; `waencrypt` hands both to the database it builds, and `Database14/15.encrypt`
+start from that prefix rather than an empty one. Real backups carry an unknown varint field 6
+this schema has no name for, and protobuf preserves it across a parse and a `CopyFrom` -- so
+carrying the header through keeps it, where rebuilding from `Props` alone dropped 2 bytes and
+made byte-identical output impossible. Only msgstore backups have the feature-table flag, so
+writing it unconditionally (as `Database15` did) made every other backup a byte too long. Both
+fall back to the old behaviour when there is no reference to copy.
+
 An incremental backup (`msgstore-increment-*.crypt15`) is a third shape: its plaintext is a
 ZIP of JSON changesets, but a *compressed* one, so the ZIP header only appears after
 decompression. `lib/utils.py: test_decompression` checks for it both before and after for
@@ -149,10 +159,13 @@ that reason -- before catches `stickers.backup.crypt15`, after catches the real 
   `coverage.process_startup()`. All five tools have invocation tests; what is left uncovered is
   mostly the pycryptodome/pycryptodomex import fallback in `wadecrypt.py` and `waguess.py`, which
   cannot run in an environment where the suite runs at all.
-- `waencrypt` is beta. `--type 14 --reference` is a known failure, marked `xfail(strict=True)` in
-  `tests/tools-invocation/test_waencrypt.py`: `Props(v_features=...)` never sets `max_feature`, so
-  `get_features()` -- which only `Database14.encrypt` calls -- raises `AttributeError`. Drop the
-  marker when `props.py` is fixed. `--multi-file` and `--noparse` are declared and never read.
+- `waencrypt` is beta, but `--reference` reproduces a real backup byte for byte -- verified
+  against 13 backups off a 2.26 device, from a 239-byte `avatar-password.bkup` to a 55 MB
+  msgstore, covering SQLite, ZIP, JSON and WebP payloads. Three things have to hold at once for
+  that, and each was separately broken: the zlib level has to match (see above), the header
+  protobuf has to keep the fields this schema does not model, and the `0x01` feature-table flag
+  has to be written only when the original had it. `--multi-file` and `--noparse` are declared
+  and never read.
   Its output positional -- like `wadecrypt`'s -- is deliberately a plain `str` and not an
   `argparse.FileType('wb')`: that type opens the file during parsing, so it was emptied before
   any check had run. The existence guard at the top of `encrypt()`/`decrypt()` only works while

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ usage: waencrypt [-h] [-f] [-y] [-v] [--enable-features [ENABLE_FEATURES ...]] [
 `waencrypt` will not write over a file that already exists; pass `-y`/`--yes` if that is what
 you want.
 
+With `--reference`, `waencrypt` reproduces the referenced backup byte for byte: the IV, the
+header (including fields this library does not model) and the compression level all come off
+it, so re-encrypting an unmodified database gives you back the md5 you started with.
+
 `-c`/`--compression-level` is the zlib level, 9 by default, which is what WhatsApp uses now.
 It compressed at 1 historically. With `--reference` the level is taken from the reference, so
 reproducing an older backup needs nothing extra; pass `-c` to override it.

--- a/src/wa_crypt_tools/lib/db/db.py
+++ b/src/wa_crypt_tools/lib/db/db.py
@@ -12,6 +12,13 @@ class Database(abc.ABC):
     An abstract class that represents a database.
     """
     iv: bytes
+    # The header protobuf this database was parsed from, when it was parsed from one.
+    # DatabaseFactory sets it; encrypt() rebuilds the header on top of it so that anything
+    # WhatsApp put there which this schema does not model survives a re-encryption.
+    prefix = None
+    # Whether the source carried the 0x01 byte that flags the feature table. None when this
+    # database was not parsed from a file, in which case encrypt() falls back to its own rule.
+    feature_table = None
 
     @abc.abstractmethod
     def __str__(self):

--- a/src/wa_crypt_tools/lib/db/db14.py
+++ b/src/wa_crypt_tools/lib/db/db14.py
@@ -42,17 +42,25 @@ class Database14(Database):
         cipher.IV = self.iv
         from wa_crypt_tools.proto import backup_prefix_pb2 as prefix
         from wa_crypt_tools.proto import key_type_pb2 as key_type
-        prefix = prefix.BackupPrefix()
-        prefix.key_type = 0
-        prefix.c14_cipher.CopyFrom(cipher)
+        header = prefix.BackupPrefix()
+        if self.prefix is not None:
+            # Start from the header this database was parsed from, so that whatever WhatsApp
+            # put there and this schema does not model comes along. Current backups carry a
+            # field we have no name for, and losing it is the whole difference between a
+            # re-encryption that works and one that reproduces the original byte for byte.
+            header.CopyFrom(self.prefix)
+        header.key_type = 0
+        header.c14_cipher.CopyFrom(cipher)
 
-        prefix.info.CopyFrom(props.get_proto())
-        prefix = prefix.SerializeToString()
+        header.info.CopyFrom(props.get_proto())
+        prefix = header.SerializeToString()
         out = b''
         file_hash = md5()
         out += len(prefix).to_bytes(1, byteorder='big')
         file_hash.update(out)
-        if len(props.get_features()) > 0:
+        # As above: what the source had wins, and the feature list decides only when there
+        # was no source to copy.
+        if self.feature_table if self.feature_table is not None else len(props.get_features()) > 0:
             out += b'\x01'
             file_hash.update(b'\x01')
         out += prefix

--- a/src/wa_crypt_tools/lib/db/db15.py
+++ b/src/wa_crypt_tools/lib/db/db15.py
@@ -78,18 +78,28 @@ class Database15(Database):
         cipher.IV = self.iv
         from wa_crypt_tools.proto import backup_prefix_pb2 as prefix
         from wa_crypt_tools.proto import key_type_pb2 as key_type
-        prefix = prefix.BackupPrefix()
-        prefix.key_type = key_type.Key_Type.HSM_CONTROLLED
-        prefix.c15_iv.CopyFrom(cipher)
+        header = prefix.BackupPrefix()
+        if self.prefix is not None:
+            # Start from the header this database was parsed from, so that whatever WhatsApp
+            # put there and this schema does not model comes along. Current backups carry a
+            # field we have no name for, and losing it is the whole difference between a
+            # re-encryption that works and one that reproduces the original byte for byte.
+            header.CopyFrom(self.prefix)
+        header.key_type = key_type.Key_Type.HSM_CONTROLLED
+        header.c15_iv.CopyFrom(cipher)
 
-        prefix.info.CopyFrom(props.get_proto())
-        prefix = prefix.SerializeToString()
+        header.info.CopyFrom(props.get_proto())
+        prefix = header.SerializeToString()
         out = b''
         file_hash = md5()
         out += len(prefix).to_bytes(1, byteorder='big')
         file_hash.update(out)
-        out += b'\x01'
-        file_hash.update(b'\x01')
+        # Only msgstore backups carry the feature table flag. When this database came from a
+        # file we know whether that one had it; otherwise keep writing it, as this has always
+        # done, since a bare Database15 is only ever built for a msgstore.
+        if self.feature_table is None or self.feature_table:
+            out += b'\x01'
+            file_hash.update(b'\x01')
         out += prefix
         file_hash.update(prefix)
         cipher = AES.new(key.get(), AES.MODE_GCM, self.iv)

--- a/src/wa_crypt_tools/lib/db/dbfactory.py
+++ b/src/wa_crypt_tools/lib/db/dbfactory.py
@@ -108,6 +108,8 @@ class DatabaseFactory:
                 db = Database15(props=props) if is_crypt15 else Database14(props=props)
                 db.iv = iv
                 db.file_hash = file_hash
+                db.prefix = header
+                db.feature_table = bool(msgstore_features_flag)
                 if len(iv) != 16:
                     raise IntegrityError("IV is not 16 bytes long but is {} bytes long"
                                          .format(len(iv)), data=db)

--- a/src/wa_crypt_tools/lib/props.py
+++ b/src/wa_crypt_tools/lib/props.py
@@ -9,6 +9,14 @@ class Props:
                  backup_version: int = C.DEFAULT_BACKUP_VERSION):
         if v_features is not None:
             self.props = v_features
+            # max_feature is not part of the protobuf -- it is only how far get_features()
+            # counts -- so a props built from a parsed header has to get one from somewhere
+            # or every call raises AttributeError. The schema itself is the answer, and
+            # reading it here means this keeps up when the proto grows a feature.
+            self.max_feature = max(
+                (int(name[2:]) for name in v_features.DESCRIPTOR.fields_by_name
+                 if name.startswith("f_") and name[2:].isdigit()),
+                default=C.DEFAULT_MAX_FEATURE)
             return
         self.props = backup_expiry.BackupExpiry()
         self.props.app_version = wa_version

--- a/src/wa_crypt_tools/waencrypt.py
+++ b/src/wa_crypt_tools/waencrypt.py
@@ -124,6 +124,8 @@ def encrypt(args):
     # If specified, use the IV from the command line
     iv = None
     props = None
+    prefix = None
+    feature_table = None
     if not args.reference:
         if args.iv:
             iv = bytes.fromhex(args.iv)
@@ -140,6 +142,10 @@ def encrypt(args):
             reference = e.data
         iv: bytes = reference.get_iv()
         props = reference.props
+        # The reference's own header, carried through to the output: it may hold fields this
+        # schema does not model, and reproducing the reference means keeping them.
+        prefix = reference.prefix
+        feature_table = reference.feature_table
         if args.compression_level is None:
             args.compression_level = compression_level_of(key, reference, args.reference)
     if args.compression_level is None:
@@ -151,6 +157,8 @@ def encrypt(args):
         db = Database14(iv=iv)
     else:
         db = Database12(key=key, iv=iv)
+    db.prefix = prefix
+    db.feature_table = feature_table
     if args.no_compress:
         encrypted = db.encrypt(key, props, data)
     else:

--- a/tests/lib/test_props.py
+++ b/tests/lib/test_props.py
@@ -49,6 +49,17 @@ class TestProps:
         assert props.get_proto() is parsed
         assert props.get_jid() == "67"
 
+    def test_features_are_readable_off_a_parsed_header_too(self):
+        # Props(v_features=...) is how DatabaseFactory wraps a header it has just parsed.
+        # It never set max_feature, so get_features() -- the only thing that reads it --
+        # raised AttributeError on every props built that way.
+        from wa_crypt_tools.proto import backup_expiry_pb2 as backup_expiry
+        parsed = backup_expiry.BackupExpiry()
+        parsed.f_5 = True
+        parsed.f_13 = True
+        parsed.f_39 = True
+        assert Props(v_features=parsed).get_features() == [5, 13, 39]
+
     def test_wa_version_and_jid_are_kept(self):
         props = Props(wa_version="2.22.5.13", jid="67", features=[5], max_feature=37)
         assert props.get_jid() == "67"

--- a/tests/tools-invocation/test_waencrypt.py
+++ b/tests/tools-invocation/test_waencrypt.py
@@ -8,6 +8,7 @@ across platforms. The one byte-for-byte check is guarded on that.
 
 import os.path
 import zlib
+from hashlib import md5
 
 import pytest
 
@@ -76,6 +77,40 @@ class TestRoundTrips:
         assert "Features: [5, 7, 13]" in out
 
 
+def with_unknown_header_field(source: str, dest: str, field: bytes = b'\x30\x03'):
+    """
+    Copies a backup, adding a protobuf field the schema does not model to its header.
+
+    Real 2.26 backups carry exactly this: field 6, varint, value 3. The header is rebuilt
+    around it -- the size byte grows, and the trailing md5 covers the header, so it has to be
+    recomputed -- but the ciphertext and its authentication tag are untouched.
+    """
+    raw = open(source, 'rb').read()
+    size = raw[0]
+    offset = 2 if raw[1] == 1 else 1
+    proto = raw[offset:offset + size] + field
+    body = raw[offset + size:-16]  # ciphertext and tag, without the md5
+    header = bytes([len(proto)]) + raw[1:offset] + proto
+    with open(dest, 'wb') as f:
+        f.write(header + body + md5(header + body).digest())
+
+
+def without_feature_table_flag(source: str, dest: str):
+    """
+    Copies a backup, dropping the 0x01 byte that flags the feature table.
+
+    Every backup that is not a msgstore lacks it -- wa.db, chatsettingsbackup and the rest --
+    so reproducing one means not writing a byte the original never had.
+    """
+    raw = open(source, 'rb').read()
+    size = raw[0]
+    assert raw[1] == 1, "source already has no feature table flag"
+    body = raw[2 + size:-16]
+    header = bytes([size]) + raw[2:2 + size]
+    with open(dest, 'wb') as f:
+        f.write(header + body + md5(header + body).digest())
+
+
 class TestReference:
     """--reference copies the props off a real backup, which is the documented workflow."""
 
@@ -94,11 +129,31 @@ class TestReference:
         assert ret == 0, out
         assert cmp_files(ROUNDTRIP, PLAIN)
 
-    @pytest.mark.xfail(strict=True, reason=(
-        "Props(v_features=...) never sets max_feature, so get_features() -- which "
-        "Database14.encrypt calls and Database15.encrypt does not -- raises AttributeError. "
-        "Remove this marker when props.py is fixed."))
+    def test_an_unknown_header_field_is_carried_through(self, tmp_path):
+        # WhatsApp puts a field in the header that this schema does not model, and rebuilding
+        # the header from Props alone drops it. Those two bytes are the entire difference
+        # between a re-encryption that merely works and one that reproduces the original.
+        ref = str(tmp_path / "unknown-field.crypt15")
+        with_unknown_header_field("tests/res/msgstore.db.crypt15", ref)
+        out, ret = Propen(["waencrypt", "--reference", ref, KEY15, PLAIN, OUT])
+        assert ret == 0, out
+        if CLASSIC_ZLIB:
+            assert cmp_files(OUT, ref)
+
+    def test_a_reference_without_a_feature_table_stays_without_one(self, tmp_path):
+        # Database15 wrote the 0x01 flag unconditionally, so every non-msgstore backup came
+        # back one byte longer than it went in.
+        ref = str(tmp_path / "no-feature-table.crypt15")
+        without_feature_table_flag("tests/res/msgstore.db.crypt15", ref)
+        out, ret = Propen(["waencrypt", "--reference", ref, KEY15, PLAIN, OUT])
+        assert ret == 0, out
+        if CLASSIC_ZLIB:
+            assert cmp_files(OUT, ref)
+
     def test_a_crypt14_reference_works_too(self):
+        # This used to raise AttributeError out of Props.max_feature, because encrypt() asked
+        # the props whether to write the feature table flag and props built from a reference
+        # never set it. It reads the flag off the reference now and never asks.
         out, ret = Propen("waencrypt --type 14 --reference tests/res/msgstore.db.crypt14 "
                           "{} {} {}".format(KEY14, PLAIN, OUT))
         assert ret == 0, out


### PR DESCRIPTION
`waencrypt --reference` now gives back a file with the md5 it started with.

Verified against **13 real backups** pulled off a WhatsApp 2.26 device — a 55 MB msgstore, an incremental backup, stickers, settings, and files as small as 239 bytes, spanning SQLite, ZIP, JSON and WebP payloads. All 13 reproduce byte for byte.

Closes the gap [#190](https://github.com/ElDavoo/wa-crypt-tools/issues/190) describes, where `code-consensus` found level 9 got *"within 2 bytes of the original file size. But there is still no exact match."*

## The 2 bytes were the header, not the compression

Python's `zlib.compress(data, 9)` already reproduces WhatsApp's compressed stream **exactly** — 55,924,068 bytes, byte for byte identical. Confirmed by splicing the original header onto our own encryption, which reproduced the file precisely.

The header was the whole difference. `encrypt()` rebuilt it from `Props` alone, and real backups carry an **unknown varint field 6** that this schema has no name for:

```
whatsapp: 8601 0801 1a12...b80201 3003
ours:     8401 0801 1a12...b80201
                                 ^^^^ field 6, varint, value 3
```

Protobuf preserves unknown fields across a parse and a `CopyFrom`, so `DatabaseFactory` keeps the header it parsed on `db.prefix` and `encrypt()` builds on top of it instead of an empty message. That also future-proofs the header against fields this library has never heard of.

## And one byte on every non-msgstore backup

`Database15` wrote the `0x01` feature-table flag unconditionally. Only msgstore backups have it, so `wa.db`, `chatsettingsbackup`, the stickers and the rest each came out exactly one byte longer than they went in. Whether the source had it is recorded on the database and honoured; the old behaviour is kept when there is no reference.

## Fixes the crypt14 crash from #125

`waencrypt --type 14 --reference` raised `AttributeError: 'Props' object has no attribute 'max_feature'`, exactly as reported in [#125](https://github.com/ElDavoo/wa-crypt-tools/issues/125). `Database14.encrypt` called `get_features()` only to decide whether to write that same flag, which it no longer needs to ask. The `xfail(strict=True)` pinning it turned into an XPASS on the first run and has been dropped.

The underlying hole is fixed too: `Props(v_features=...)` — how a parsed header becomes props — never set `max_feature`, so `get_features()` raised on every props built that way. It now comes off the protobuf schema, so it keeps up when the proto grows a feature.

## Results

| backup | size | |
|---|---|---|
| `msgstore.db.crypt15` | 55,924,236 | ✅ |
| `msgstore-increment-*.crypt15` (ZIP) | 181,452 | ✅ |
| `status_backup.db` | 410,730 | ✅ |
| `stickers_db.bak` | 266,272 | ✅ |
| stickers (WebP) ×2 | 24,607 / 11,730 | ✅ |
| `wa.db` | 19,637 | ✅ |
| `chatsettingsbackup.db` | 7,066 | ✅ |
| `offloaded-media.db` | 1,682 | ✅ |
| `commerce_backup.db` | 1,077 | ✅ |
| `backup_settings.json` (JSON) | 385 | ✅ |
| `chatlock_backup.bkup` | 270 | ✅ |
| `avatar-password.bkup` | 239 | ✅ |

## Testing

Test-first for each fix. 256 passed, 94% coverage — and no xfailed, because the one that was there is now fixed.

New tests build a reference carrying an unknown header field, and one with the feature-table flag stripped, then assert the re-encryption matches byte for byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKq8MBAKTJkMd5DGNY3jdW