### PR TITLE
Default to a current backup's header, and warn about fields we cannot name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,16 @@ logged its failure and then continued anyway.
   `E2EE_PASSWORD`, `E2EE_ENCRYPTION_KEY`, `E2EE_PASSKEY` -- and what this project called
   `HSM_CONTROLLED` is really `E2EE_DEPRECATED`. Renaming a field cannot change the wire format,
   so nothing about what is read or written changes.
+- **The defaults are a real 2.26.34.7 backup's.** `DEFAULT_APP_VERSION` was 2.23.18.12 and
+  `DEFAULT_BACKUP_VERSION` was 0; the feature list was missing flag 34. With the right `--iv`
+  and `--jid`, `waencrypt` given no reference at all now writes the same header bytes as the
+  phone does. `Database15` also takes a `key_type`, defaulting to `E2EE_ENCRYPTION_KEY`, which
+  is what `key_type_new` holds in every current backup -- pass `None` to reproduce a backup
+  from before that field existed. A `--reference` still wins over all of it.
+- **A header field this schema cannot name is now reported.** `waguess`, `wadecrypt` and
+  `wainfo` warn, naming the message and the field number. Unknown fields survive a parse and
+  come back on re-encryption, so nothing broke while `key_type_new` went unnoticed in every
+  2.26 backup -- and nothing said anything either. Now it would.
 - `wainfo` printed the crypt15 IV on the same line as the heading that introduces it, unlike
   the crypt14 branch beside it, so anything reading its output line by line missed the IV.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,10 +145,20 @@ are intended: `wadecrypt` and `wainfo` handle every one of those files, and broa
 check would cost the search its only defence against false offsets.
 
 `key_type_new` (field 6) is why re-encryption had to start from the parsed header: every
-crypt15 backup from 2.26 sets it to `E2EE_ENCRYPTION_KEY`, and nothing here writes it. It is a
-modelled field now rather than an unknown one, but `waencrypt` still only ever reproduces what a
-`--reference` carried -- without a reference the output has no field 6, which the app would read
-as the default `WA_PROVIDED`. Whether that matters for a restore has not been established.
+crypt15 backup from 2.26 sets it to `E2EE_ENCRYPTION_KEY`. It is written by default now --
+`C.DEFAULT_KEY_TYPE`, through `Database15(key_type=...)` -- but only when there is no `prefix` to
+rebuild on, because a reference from before the field existed must not grow one. `key_type=None`
+asks for that older shape, which is what `tests/test_encrypt.py` does to reproduce the 2022
+fixtures. The rest of the defaults in `constants.py` are that same 2.26 backup's, so with the
+right `--iv` and `--jid` a reference-less `waencrypt` writes the phone's exact header bytes;
+`tests/test_encrypt.py` therefore has to pass `backup_version=0` explicitly, since the default
+is 1 now.
+
+`DatabaseFactory` warns about any header field the schema cannot name
+(`lib/utils.py: unknown_header_fields`, which walks nested messages too). That is the tripwire
+this did not have: protobuf keeps unknown fields and hands them back on serialisation, so
+`key_type_new` sat in every 2.26 backup without breaking anything and without being noticed
+either. Note `FieldDescriptor.label` is gone in protobuf 7 -- use `is_repeated`.
 
 **A re-encryption is built on the parsed header, not from scratch.** `DatabaseFactory` keeps the
 `BackupPrefix` it parsed on `db.prefix` and whether the `0x01` feature-table flag was there on

--- a/README.md
+++ b/README.md
@@ -92,22 +92,23 @@ waencrypt.py:89         : [I] Done!
 
 You need to supply the following parameters:  
 
-1) The feature list: Only for 2019+ databases. A list of numbered boolean
-   properties related to your database. There is currently no way to infer them
-   from a database file. In the example, we will just use my backup's feature list,
-   but don't expect it to work for you.  
+1) The feature list: Only for 2019+ databases. These are really the database migration flags
+   WhatsApp records in the header, and there is no way to infer them from a database file. The
+   defaults are what a 2.26.34.7 msgstore carries, which is all of them.
 2) The max feature number, which is 39 at the time of writing
-3) The version of the app that encrypted the file: Use a reasonable value,
-   like 2.24.8.6 or something.  
-4) Jid: The last 2 numbers of your phone number  
+3) The version of the app that encrypted the file: defaults to 2.26.34.7.
+4) Jid: The last 2 numbers of your phone number -- this one really is yours, and defaults to 00
 5) Backup version: Use 1.
 
-Defaults will be used if parameters are omitted.  
+Defaults will be used if parameters are omitted, and they are taken from a real 2.26.34.7
+backup: given the right `--iv` and `--jid`, `waencrypt` writes the same header bytes as the
+phone does, with no reference at all. Passing `--reference` is still the better way, since it
+takes the IV, the compression level and the whole header off a backup you already have.  
 
 To sum it up:
 ```
 $ waencrypt --enable-features 5 6 7 8 9 10 11 12 13 14 15 16
- 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 39 --type 15 --wa-version 2.26.1.2 --jid 00 --backup
+ 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 39 --type 15 --wa-version 2.26.34.7 --jid 00 --backup
 -version 1 encrypted_backup.key msgstore.db msgstore-new.db.crypt15 
 waencrypt.py:57         : [W] This script is in beta stage
 waencrypt.py:89         : [I] Done!
@@ -261,15 +262,19 @@ See the [CITATION.cff](CITATION.cff) file for citation information.
 
 ### I will happily accept pull requests for the currently open issues. :)
 
-### Last tested version (don't expect this to be updated)
-Stable: 
-2.24.16.76  
-Beta: 
-2.24.26.11
+### Last tested version
+Stable:
+2.26.34.7
+
+Tested against real backups off a 2.26.34.7 device: a msgstore, an incremental backup, and the
+`WhatsApp/Backups/` set (`wa.db`, `status_backup.db`, `stickers_db.bak`, `chatsettingsbackup.db`,
+`commerce_backup.db`, `offloaded-media.db`, `backup_settings.json`, `avatar-password.bkup`,
+`chatlock_backup.bkup`, individual stickers). All thirteen decrypt, and re-encrypt back to the
+byte-for-byte original.
 
 #### Business
-Stable:  
-2.24.23.78
+Stable:
+2.24.23.78 (not retested)
 
 #### Protobuf automatic fix
 

--- a/src/wa_crypt_tools/lib/constants.py
+++ b/src/wa_crypt_tools/lib/constants.py
@@ -28,15 +28,23 @@ class C:
     DEFAULT_DATA_OFFSET = 122
     DEFAULT_IV_OFFSET = 8
 
-    # Encryption constants
-    DEFAULT_APP_VERSION = "2.23.18.12"
+    # Encryption constants. These are what a real msgstore backup off WhatsApp 2.26.34.7
+    # carries, so that a waencrypt run given no reference still produces a current-looking
+    # header rather than a 2023-looking one.
+    DEFAULT_APP_VERSION = "2.26.34.7"
+    # Not taken from a real backup, for obvious reasons: this is the owner's phone number.
     DEFAULT_JID_SUFFIX = "00"
-    DEFAULT_BACKUP_VERSION = 0
-    # The Props I got from a recent backup of mine
+    DEFAULT_BACKUP_VERSION = 1
+    # BackupPrefix.key_type_new, which says which kind of end-to-end key was used. 3 is
+    # E2EE_ENCRYPTION_KEY -- the 64-digit key -- and is what every 2.26 crypt15 backup carries.
+    # Backups from before the field existed are reproduced by passing None instead.
+    DEFAULT_KEY_TYPE = 3
+    # Every migration flag the schema has. A current msgstore sets all of them -- 34 was the
+    # one missing from this list, and 38 is not a flag at all but backup_export_file_size.
     DEFAULT_FEATURE_LIST = [5, 6, 7, 8, 9,
                             10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
                             20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-                            30, 31, 32, 33, 35, 36, 37, 39]
+                            30, 31, 32, 33, 34, 35, 36, 37, 39]
     # Old backups might not have knowledge of the new features (in 2022 backups the max is 37)
     DEFAULT_MAX_FEATURE = 39
 

--- a/src/wa_crypt_tools/lib/db/db15.py
+++ b/src/wa_crypt_tools/lib/db/db15.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 import logging
 from hashlib import md5
 from os import urandom
 
 from Cryptodome.Cipher import AES
 
+from wa_crypt_tools.lib.constants import C
 from wa_crypt_tools.lib.props import Props
 
 log = logging.getLogger(__name__)
@@ -18,10 +21,14 @@ class Database15(Database):
         return "Database15"
         # todo
 
-    def __init__(self, *, iv: bytes = None, props: Props = None):
+    def __init__(self, *, iv: bytes = None, props: Props = None,
+                 key_type: int | None = C.DEFAULT_KEY_TYPE):
         self.file_hash = md5()
         # just store it for now
         self.props = props
+        # None writes no key_type_new at all, which is what a backup from before WhatsApp
+        # added the field looks like.
+        self.key_type = key_type
         if iv:
             if len(iv) != 16:
                 raise IntegrityError("IV is not 16 bytes long but is {} bytes long".format(len(iv)))
@@ -86,6 +93,11 @@ class Database15(Database):
             # re-encryption that works and one that reproduces the original byte for byte.
             header.CopyFrom(self.prefix)
         header.key_type_deprecated = key_type.Key_Type.E2EE_DEPRECATED
+        if self.prefix is None and self.key_type is not None:
+            # Only when there is no reference to reproduce: a reference's own value has already
+            # been copied in above, and overwriting it would put the field into backups made
+            # before it existed.
+            header.key_type_new = self.key_type
         header.e2ee_key_data.CopyFrom(cipher)
 
         header.backup_metadata.CopyFrom(props.get_proto())

--- a/src/wa_crypt_tools/lib/db/dbfactory.py
+++ b/src/wa_crypt_tools/lib/db/dbfactory.py
@@ -7,7 +7,7 @@ from wa_crypt_tools.lib.db.db14 import Database14
 from wa_crypt_tools.lib.db.db15 import Database15
 from wa_crypt_tools.lib.errors import HeaderError, IntegrityError
 from wa_crypt_tools.lib.props import Props
-from wa_crypt_tools.lib.utils import header_info
+from wa_crypt_tools.lib.utils import header_info, unknown_header_fields
 
 log = logging.getLogger(__name__)
 
@@ -101,6 +101,16 @@ class DatabaseFactory:
 
                 # We are done here
                 log.debug(header_info(header))
+
+                # Anything the schema cannot name is how a format change announces itself.
+                extra = unknown_header_fields(header)
+                if extra:
+                    log.warning("This header carries {} this schema does not know: {}.\n    "
+                                "Your WhatsApp is probably newer than this library. The backup "
+                                "still reads, and re-encrypting keeps the field, but please "
+                                "report it."
+                                .format("a field" if len(extra) == 1 else
+                                        "{} fields".format(len(extra)), ", ".join(extra)))
 
                 props = Props(v_features=header.backup_metadata)
                 # The database is built even when the IV is the wrong length, so that --force

--- a/src/wa_crypt_tools/lib/utils.py
+++ b/src/wa_crypt_tools/lib/utils.py
@@ -157,6 +157,39 @@ def get_mcrypt1_name(*, key, name: str, md5: bytes) -> bytes:
     return media_hash
 
 
+def unknown_header_fields(header) -> list[str]:
+    """
+    Names the fields of a parsed header that this schema does not describe, innermost included.
+
+    A WhatsApp format change shows up here first. Field 6 of BackupPrefix sat in every 2.26
+    backup for a long time without anyone noticing, because protobuf keeps what it cannot name
+    and hands it back on serialisation -- so nothing broke and nothing said anything either.
+    Returns descriptions like "BackupPrefix field 7", empty when the schema covers everything.
+    """
+    try:
+        from google.protobuf.unknown_fields import UnknownFieldSet
+    except ImportError:  # pragma: no cover - only on a protobuf too old to have it
+        return []
+
+    found: list[str] = []
+
+    def walk(message):
+        try:
+            unknown = UnknownFieldSet(message)
+        except (NotImplementedError, TypeError):  # pragma: no cover - implementation-dependent
+            return
+        for field in unknown:
+            found.append("{} field {}".format(message.DESCRIPTOR.name, field.field_number))
+        for descriptor, value in message.ListFields():
+            # is_repeated rather than the old label constant: protobuf 7 dropped label with
+            # the move to editions.
+            if descriptor.type == descriptor.TYPE_MESSAGE and not descriptor.is_repeated:
+                walk(value)
+
+    walk(header)
+    return found
+
+
 def header_info(header):
     """
     shows all header, information including the feature vector

--- a/tests/lib/db/test_dbfactory.py
+++ b/tests/lib/db/test_dbfactory.py
@@ -36,6 +36,42 @@ def crypt15_header(*, iv: bytes) -> bytes:
     return len(serialized).to_bytes(1, byteorder='big') + b'\x01' + serialized
 
 
+def crypt15_header_with_extra(*, iv: bytes, extra: bytes) -> bytes:
+    """The same header with raw protobuf bytes appended that the schema does not describe."""
+    from wa_crypt_tools.proto import backup_prefix_pb2 as prefix
+    from wa_crypt_tools.proto import key_type_pb2 as key_type
+    header = prefix.BackupPrefix()
+    header.key_type_deprecated = key_type.Key_Type.E2EE_DEPRECATED
+    header.e2ee_key_data.encryption_iv = iv
+    header.backup_metadata.app_version = "2.22.5.13"
+    serialized = header.SerializeToString() + extra
+    return len(serialized).to_bytes(1, byteorder='big') + b'\x01' + serialized
+
+
+class TestUnknownFields:
+    """
+    A header field this schema has never heard of is how a WhatsApp format change first shows
+    up. It used to pass in silence -- field 6 sat in every 2.26 backup unnoticed until a
+    byte-for-byte comparison went looking for it -- so now it says so.
+    """
+
+    def test_an_unknown_top_level_field_is_reported(self, caplog):
+        # Field 7, varint, value 1: the shape a new BackupPrefix field would arrive in.
+        stream = as_stream(crypt15_header_with_extra(iv=b'\x00' * 16, extra=b'\x38\x01'))
+        DatabaseFactory.from_file(stream)
+        assert "BackupPrefix field 7" in caplog.text
+
+    def test_an_unknown_nested_field_is_reported(self, caplog):
+        # Inside backup_metadata: field 4 of BackupPrefix, then field 45 within it.
+        stream = as_stream(crypt15_header_with_extra(iv=b'\x00' * 16, extra=b'\x22\x03\xe8\x02\x01'))
+        DatabaseFactory.from_file(stream)
+        assert "BackupExpiry field 45" in caplog.text
+
+    def test_a_header_this_schema_covers_says_nothing(self, caplog):
+        DatabaseFactory.from_file(as_stream(crypt15_header(iv=b'\x00' * 16)))
+        assert "does not know" not in caplog.text
+
+
 class ExplodingStream(io.BufferedReader):
     """A stream that fails where the factory has to cope: on read, or on the crypt12 rewind."""
 

--- a/tests/test_encrypt.py
+++ b/tests/test_encrypt.py
@@ -26,9 +26,13 @@ def decrypt_roundtrip(key, data: bytes) -> bytes:
 class TestEncryption:
     def test_encryption15(self):
         key = KeyFactory.new("tests/res/encrypted_backup.key")
+        # backup_version=0 explicitly: the fixtures are 2022 backups and the default is now 1,
+        # which is what a current device writes.
         props = Props(wa_version="2.22.5.13", jid="67", features=[5, 7, 8, 13, 14, 19, 22, 25, 28, 30, 31, 32, 36, 37],
-                      max_feature=37)
-        db = Database15(iv=bytes.fromhex("C395EE009CF8B68AC0EA760550F6559C"))
+                      max_feature=37, backup_version=0)
+        # key_type=None: the fixture is a 2022 backup, from before WhatsApp added
+        # key_type_new to the header, so reproducing it means not writing that field.
+        db = Database15(iv=bytes.fromhex("C395EE009CF8B68AC0EA760550F6559C"), key_type=None)
         with open("tests/res/msgstore.db", 'rb') as f:
             orig = f.read()
         data = db.encrypt(
@@ -43,8 +47,10 @@ class TestEncryption:
 
     def test_encryption14(self):
         key = KeyFactory.new("tests/res/key")
+        # backup_version=0 explicitly: the fixtures are 2022 backups and the default is now 1,
+        # which is what a current device writes.
         props = Props(wa_version="2.22.5.13", jid="67", features=[5, 7, 8, 13, 14, 19, 22, 25, 28, 30, 31, 32, 36, 37],
-                      max_feature=37)
+                      max_feature=37, backup_version=0)
         db = Database14(iv=bytes.fromhex("EA53CEAE36ECAB50BC331AEB62491625"))
         with open("tests/res/msgstore.db", 'rb') as f:
             orig = f.read()


### PR DESCRIPTION
## Defaults

They were a 2023 backup's: `DEFAULT_APP_VERSION` 2.23.18.12, `DEFAULT_BACKUP_VERSION` 0, and a feature list missing flag 34. They are a real WhatsApp **2.26.34.7** msgstore's now.

With the right `--iv` and `--jid`, `waencrypt` given **no `--reference` at all** now writes the same header bytes the phone does:

| | device | `waencrypt`, no reference |
|---|---|---|
| `key_type_deprecated` | `E2EE_DEPRECATED` | `E2EE_DEPRECATED` |
| `key_type_new` | `E2EE_ENCRYPTION_KEY` | `E2EE_ENCRYPTION_KEY` |
| `app_version` | 2.26.34.7 | 2.26.34.7 |
| `backup_version` | 1 | 1 |
| flags set | 34 | 34 |

**header bytes identical: True**

`DEFAULT_JID_SUFFIX` stays `00` on purpose — that field is the owner's phone number and has no business being copied out of anyone's backup.

`Database15` takes a `key_type`, defaulting to `C.DEFAULT_KEY_TYPE` (`E2EE_ENCRYPTION_KEY`), which is what `key_type_new` holds in every current backup and what nothing here wrote before. It applies only when there is no parsed header to rebuild on, so a `--reference` from before the field existed does not grow one. `key_type=None` asks for that older shape explicitly, which is how `test_encrypt.py` still reproduces the 2022 fixtures byte for byte.

## Warning about unknown fields

`DatabaseFactory` now reports any header field the schema cannot name, nested messages included:

```
[W] This header carries a field this schema does not know: BackupPrefix field 7.
    Your WhatsApp is probably newer than this library. The backup still reads,
    and re-encrypting keeps the field, but please report it.
```

This is the tripwire that was missing. Protobuf keeps unknown fields and hands them back on serialisation, so `key_type_new` sat in every 2.26 backup without breaking anything — and without anything saying so either. It took a byte-for-byte comparison to find it. Next time the format moves, `wadecrypt` says so on the first run.

Quiet on every current backup, since the schema now covers them; and a header with a field from the future still decrypts and still re-encrypts byte-identically.

## Rechecked

Against **thirteen freshly written backups** off the device (msgstore rewritten at 11:22 today), all thirteen re-encrypt to the byte-for-byte original.

README's "last tested version" is 2.26.34.7, with the list of backup kinds actually covered. Business stays 2.24.23.78, marked not retested.

259 passed, 94% coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKq8MBAKTJkMd5DGNY3jdW