### PR TITLE
Keep the user's own path separators when naming the output

### DIFF
--- a/src/wa_crypt_tools/gui/core.py
+++ b/src/wa_crypt_tools/gui/core.py
@@ -106,10 +106,14 @@ def suggest_output(encrypted_path: str) -> str:
     """The name to pre-fill the output field with, so the user touches two controls, not three."""
     if not encrypted_path:
         return ""
-    p = Path(encrypted_path)
+    # Sliced off the string rather than rebuilt through Path. str(Path(...)) normalises the
+    # separators to the platform's, so on Windows "tests/res/msgstore.db.crypt15" came back as
+    # "tests\\res\\msgstore.db" -- a different-looking path than the one the user just chose,
+    # in the field right underneath it. The suffix is at the end of the whole string as well as
+    # at the end of the name, so taking it off the string leaves everything else untouched.
     for suffix in BACKUP_SUFFIXES:
-        if p.name.lower().endswith(suffix):
-            return str(p.with_name(p.name[: -len(suffix)]))
+        if Path(encrypted_path).name.lower().endswith(suffix):
+            return encrypted_path[: len(encrypted_path) - len(suffix)]
     return encrypted_path + ".decrypted"
 
 

--- a/tests/gui/test_core.py
+++ b/tests/gui/test_core.py
@@ -9,6 +9,7 @@ only widget wiring, which test_app.py smoke-tests.
 
 import logging
 import queue
+from pathlib import PureWindowsPath
 
 import pytest
 
@@ -130,6 +131,17 @@ class TestSuggestOutput:
 
     def test_keeps_the_directory(self):
         assert core.suggest_output("/tmp/some dir/msgstore.db.crypt15") == "/tmp/some dir/msgstore.db"
+
+    def test_the_separators_the_user_typed_are_the_ones_they_get_back(self, monkeypatch):
+        # Forward slashes are perfectly good on Windows, and the file dialog is not the only
+        # way the field gets filled. Rebuilding the path through Path() rewrote them as
+        # backslashes, so the output field disagreed with the input field directly above it.
+        #
+        # Patching Path is what makes that reachable off Windows at all: the old code passed
+        # everywhere else, and the bug reached main and sat there for two commits.
+        monkeypatch.setattr(core, "Path", PureWindowsPath)
+        assert core.suggest_output("tests/res/msgstore.db.crypt15") == "tests/res/msgstore.db"
+        assert core.suggest_output(r"C:\dir\msgstore.db.crypt15") == r"C:\dir\msgstore.db"
 
     def test_nothing_chosen_yet(self):
         assert core.suggest_output("") == ""


### PR DESCRIPTION
CI has been **red on both Windows legs since wagui landed** (`932e4ce`, and still at `829b6e0`).
Two tests fail there and nowhere else:

```
FAILED tests/gui/test_core.py::TestSuggestOutput::test_keeps_the_directory
  assert '\tmp\some dir\msgstore.db' == '/tmp/some dir/msgstore.db'
FAILED tests/gui/test_app.py::TestWindow::test_choosing_a_backup_describes_it_and_names_the_output
  assert 'tests\res\msgstore.db' == 'tests/res/msgstore.db'
```

`suggest_output` rebuilt the chosen path through `Path()` to take the suffix off, and
`str(Path(...))` normalises separators to the platform's. So on Windows a backup at
`tests/res/msgstore.db.crypt15` filled the output field with `tests\res\msgstore.db` — a path
that looks nothing like the one in the field directly above it, for a change only ever meant to
drop eight characters off the end. Forward slashes are perfectly good on Windows, and the file
dialog is not the only way that field gets filled.

The suffix sits at the end of the whole string as well as at the end of the name, so slicing it
off the string does the same job and leaves everything else exactly as the user wrote it.
Behaviour is unchanged in every other case, on both platforms.

The new test patches `Path` to `PureWindowsPath`, so the same mistake becomes catchable on a
developer machine — which is where it should have been caught, rather than after two commits
of red CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ArSm665UbLHeG3mPrCy83L